### PR TITLE
Fix case sensitive header references

### DIFF
--- a/Glitter/Headers/glitter.hpp
+++ b/Glitter/Headers/glitter.hpp
@@ -2,7 +2,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 
 // System Headers
-#include <assimp/importer.hpp>
+#include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 #include <glad/glad.h>

--- a/Glitter/Sources/main.cpp
+++ b/Glitter/Sources/main.cpp
@@ -3,7 +3,7 @@
 
 // System Headers
 #include <glad/glad.h>
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
 
 // Standard Headers
 #include <cstdio>


### PR DESCRIPTION
Fixes #1 - "assimp/importer.hpp: No such file or directory".