### PR TITLE
stb_image implementation

### DIFF
--- a/Glitter/Headers/glitter.hpp
+++ b/Glitter/Headers/glitter.hpp
@@ -1,6 +1,3 @@
-// Preprocessor Directives
-#define STB_IMAGE_IMPLEMENTATION
-
 // System Headers
 #include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>

--- a/Glitter/Sources/main.cpp
+++ b/Glitter/Sources/main.cpp
@@ -1,6 +1,9 @@
 // Local Headers
 #include "glitter.hpp"
 
+// Implementation of stb_image (only add to one .cpp file)
+#define STB_IMAGE_IMPLEMENTATION
+
 // System Headers
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>

--- a/Glitter/Sources/main.cpp
+++ b/Glitter/Sources/main.cpp
@@ -1,8 +1,8 @@
-// Local Headers
-#include "glitter.hpp"
-
 // Implementation of stb_image (only add to one .cpp file)
 #define STB_IMAGE_IMPLEMENTATION
+
+// Local Headers
+#include "glitter.hpp"
 
 // System Headers
 #include <glad/glad.h>


### PR DESCRIPTION
Hello from the same guy who bugged you to support MinGW :smiley:

When I actually found time to go through OpenGL tutorials, I noticed one thing in your project. In `glitter.hpp` (which at least I noted as a file meant to be included in all GL-needing source files and simply grouping all the includes), you define `STB_IMAGE_IMPLEMENTATION`. This is required by `stb_image`, but only in one .cpp file ([source](https://github.com/nothings/stb/blob/master/stb_image.h#L4)), as it essentially unpacks the implementation of the library. You can check it yourself by creating another .cpp file and including `glitter.hpp` in it -- the project will fail to link with multiple redefinition errors. So that `#define` has to be moved into a .cpp file.

And if this behaviour is intended, then I think you should specify in readme `glitter.hpp` is only meant to be included in one .cpp file and otherwise it'll break the program.