### PR TITLE
Typo fix. The 'I' must be caps for g++ to find the headder file

### DIFF
--- a/Samples/mesh.hpp
+++ b/Samples/mesh.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // System Headers
-#include <assimp/importer.hpp>
+#include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 #include <glad/glad.h>


### PR DESCRIPTION
Your sample code would not compile without this fix. 