### PR TITLE
Sample shader improvements

### DIFF
--- a/Samples/readme.md
+++ b/Samples/readme.md
@@ -11,6 +11,7 @@ Shader shader;
 shader.attach("main.vert")
       .attach("main.frag")
       ... // and so on ...
+shader.link();
 ```
 
 There is some basic error handling to help you out if you get stuck.

--- a/Samples/shader.hpp
+++ b/Samples/shader.hpp
@@ -22,13 +22,10 @@ namespace Mirage
         // Public Member Functions
         Shader & activate();
         Shader & attach(std::string const & filename);
-        GLuint   create(std::string const & filename);
-        GLuint   get() { return mProgram; }
+        GLuint   get() const { return mProgram; }
         Shader & link();
 
         // Wrap Calls to glUniform
-        void bind(unsigned int location, float value);
-        void bind(unsigned int location, glm::mat4 const & matrix);
         template<typename T> Shader & bind(std::string const & name, T&& value)
         {
             int location = glGetUniformLocation(mProgram, name.c_str());
@@ -38,6 +35,10 @@ namespace Mirage
         }
 
     private:
+        GLuint   create(std::string const & filename);
+
+        void bind(unsigned int location, float value);
+        void bind(unsigned int location, glm::mat4 const & matrix);
 
         // Disable Copying and Assignment
         Shader(Shader const &) = delete;


### PR DESCRIPTION
# Problem

## Example shader class interface is error-prone

The example code for the shader class is very error-prone to use for users. This is from experience from some of my mates using this as a template for their project. This is because the public interface of the shader class has methods that are meant to be used in private implementations.

E.g. Someone with some knowledge of setting up OpenGL shaders, will know they have to first create the shader before attaching them. As such, they will call the method in this order:

```cpp
Shader shader;
shader.create("vert.glsl");
shader.attach("vert.glsl");
...
```

However, the correct use of this is to actually just use the `attach` method.

## The example for the shader class is in the README omitted the step to link the shaders

There is a step missing from the example code given for the sample shader class, which is that the user has to call `link` to link the shaders to the shader program.

Again, some of my mates, knowing no better, and had a fun trip trying to debug why it wouldn't work. 

After I had them turn on OpenGL debug logging, it has revealed that their shaders didn't link.

# Solution

- I've cleaned up the public interface of the shader class by moving methods that are meant to be called internally to the private region.
- I've updated the README for the shader example so that the step to call `link` is included.
- As a bonus, the `get` method for the shader class can be `const`, so I've made it `const`.

# Testing

- [x] I've compiled a simple program that uses the modified shader class and ensured that it works.